### PR TITLE
maintenance: change hashbang and imports

### DIFF
--- a/scripts/exportsecrets.py
+++ b/scripts/exportsecrets.py
@@ -1,7 +1,7 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
-import yaml
 import os
+import yaml
 
 config = yaml.safe_load(open(os.path.join(os.environ["HOME"], '.kube/config')))
 

--- a/scripts/filer.py
+++ b/scripts/filer.py
@@ -1,15 +1,15 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 from __future__ import print_function
 from ftplib import FTP
 import ftplib
 import argparse
-import requests
 import sys
 import json
 import re
 import os
 import distutils.dir_util
+import requests
 
 debug = True
 

--- a/scripts/genjob.py
+++ b/scripts/genjob.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import argparse
 import json

--- a/scripts/state.py
+++ b/scripts/state.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 from __future__ import print_function
 
@@ -17,11 +17,11 @@ def exec_state(exe_f, namespace, state):
       job = bv1.read_namespaced_job(exe, namespace=namespace)
       state['logs'][exe_i]['start_time'] = job.metadata.creation_timestamp
       state['logs'][exe_i]['end_time'] = job.status.completion_time
-      
+
       job_label_s = 'controller-uid='+job.spec.selector.match_labels['controller-uid']
       pods = cv1.list_namespaced_pod(label_selector=label_s, namespace=namespace)
 
-      try: 
+      try:
         state['logs'][exe_i]['stdout'] = read_namespaced_pod_log(pods[0].metadata.name, namespace=namespace)
       except IndexError:
         print("No pod matching job "+job.metadata.name+" could be found", file=sys.stderr)
@@ -46,7 +46,7 @@ def control_state(taskm_f, namespace, state):
     job_label_s = 'controller-uid='+job.spec.selector.match_labels['controller-uid']
     pods = cv1.list_namespaced_pod(label_selector=label_s, namespace=namespace)
 
-    try: 
+    try:
       state['system_logs'] = read_namespaced_pod_log(pods[0].metadata.name, namespace=namespace)
     except IndexError:
       print("No pod matching job "+job.metadata.name+" could be found", file=sys.stderr)

--- a/scripts/taskmaster.py
+++ b/scripts/taskmaster.py
@@ -1,15 +1,13 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 from __future__ import print_function
 import argparse
 import json
 import os
-import binascii
 import re
 import time
 import sys
 from kubernetes import client, config
-from datetime import datetime
 
 created_jobs = []
 debug = False
@@ -62,10 +60,10 @@ def run_executors(specs, namespace, volume_mounts=None, pvc_name=None):
     if volume_mounts is not None:
       spec['containers'][0]['volumeMounts'] = volume_mounts
     if pvc_name is not None:
-      spec['volumes'] = [{ 'name': task_volume_basename, 'persistentVolumeClaim': { 'readonly': False, 'claimName': pvc_name }}]
+      spec['volumes'] = [{'name': task_volume_basename, 'persistentVolumeClaim': { 'readonly': False, 'claimName': pvc_name }}]
 
     job = v1.create_namespaced_job(body=executor, namespace=namespace)
- 
+
     global created_jobs
     created_jobs.append(jobname)
 
@@ -208,7 +206,7 @@ def cleanup_pvc(data, namespace, volume_mounts, pvc_name, filer_version):
   container = posttask['spec']['template']['spec']['containers'][0]
   container['env'].append({ "name": "JSON_INPUT", "value": json.dumps(data) })
   container['args'] += ["outputs", "$(JSON_INPUT)"]
-  
+
   # insert volume mounts and pvc into posttask job template
   container['volumeMounts'] = volume_mounts
   posttask['spec']['template']['spec']['volumes'] = [ { "name": task_volume_basename, "persistentVolumeClaim": { "claimName": pvc_name} } ]
@@ -286,9 +284,9 @@ def main(argv):
 def clean_on_interrupt():
   print('Caught interrupt signal, deleting jobs and pvc', file=sys.stderr)
   bv1 = client.BatchV1Api()
-  
+
   for job in created_jobs:
-    bv1.delete_namespaced_job(job, args.namespace, client.V1DeleteOptions()) 
+    bv1.delete_namespaced_job(job, args.namespace, client.V1DeleteOptions())
 
   if created_pvc:
     cv1 = client.CoreV1Api()


### PR DESCRIPTION
The hashbang now explicitely states that python2 is needed, as well as
using env to run the first python2 binary in $PATH

The imports were reordered as recommended by pylint

Also, some trailing whitespace was cleaned up