### PR TITLE
Fix j2

### DIFF
--- a/deployment/common/tesk-svc.yaml.j2
+++ b/deployment/common/tesk-svc.yaml.j2
@@ -6,8 +6,8 @@ metadata:
     app: tesk-api
 spec:
   ports:
-  - port: {{ tesk.port }}
-    nodePort: {{ service.node_port }}   # valid only if {{service.type}} == NodePort
+  - port: {{ tesk.port }}{% if service.node_port is defined and service.type == 'NodePort' %}
+    nodePort: {{ service.node_port }}   # valid only if {{service.type}} == NodePort{% endif %}
   selector:
     app: tesk-api
-  type: {{ service.type if service.type else 'ClusterIP' }}
+  type: {% if service.type is defined %}{{ service.type }}{% else %}ClusterIP{% endif %}


### PR DESCRIPTION
This is to solve errors like:

```console
$ j2 -g "*.j2" config.ini
Traceback (most recent call last):
  File "/usr/bin/j2", line 11, in <module>
    load_entry_point('shinto-cli==0.5.0', 'console_scripts', 'j2')()
  File "/usr/lib/python2.7/site-packages/shinto_cli/cli.py", line 166, in main
    sys.argv[1:]
  File "/usr/lib/python2.7/site-packages/shinto_cli/cli.py", line 150, in render_command
    context
  File "/usr/lib/python2.7/site-packages/shinto_cli/cli.py", line 83, in render_templates_and_save
    .render(context)
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 969, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 742, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/galvaro/src/TESK/deployment/common/tesk-svc.yaml.j2", line 10, in top-level template code
    nodePort: {{ service.node_port }}   # valid only if {{service.type}} == NodePort
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'node_port'
```