### PR TITLE
Since 1.16 onwards the API - extensions/v1beta1 is deprecated

### DIFF
--- a/deployment/common/tesk-deployment.yaml.j2
+++ b/deployment/common/tesk-deployment.yaml.j2
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tesk-api


### PR DESCRIPTION
Our supported K8s version will be v1.19. 