### PR TITLE
Helm chart S3 configuration secret addition

### DIFF
--- a/charts/tesk/README.md
+++ b/charts/tesk/README.md
@@ -47,6 +47,8 @@ The first time running this command, the chart will be installed. Afterwards, it
 ```bash
 $ helm upgrade -n tesk --install tesk-release . -f secrets.yaml -f values.yaml
 ```
+*Note*: If you're running Helm 3, you might need to also use the `--create-namespace` option, as non-existent namespaces
+do not get created by default (see [this](https://github.com/helm/helm/issues/6794)). 
 
 ##  Description of values
 

--- a/charts/tesk/README.md
+++ b/charts/tesk/README.md
@@ -22,6 +22,10 @@ To deploy the application:
    client_secret: <client_secret>
  ```
 
+ * If you're using `s3` as your storage option, do not forget to add the necessary `config` and `credentials` files
+ (see [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)) under a folder named
+ **s3-config** (*charts/tesk/s3-config*).
+
  * finally execute:
 
 ```bash
@@ -52,6 +56,7 @@ See [`values.yaml`](values.yaml) for default values.
 | --- | --- | --- |
 | host_name | string | FQDN to expose the application |
 | clusterType | string |type of Kubernetes cluster; either 'kubernetes' or 'openshift'|
+| storage | string | Can be either 'openstack' or 's3' |
 | tesk.image | string | container image (including the version) to be used to run TESK API |
 | tesk.port | integer | |
 | tesk.taskmaster_image_version | string | the version of the image to be used to run TESK Taskmaster Job |

--- a/charts/tesk/s3-config/config-TEMPLATE
+++ b/charts/tesk/s3-config/config-TEMPLATE
@@ -1,0 +1,3 @@
+[default]
+region=us-west-2
+output=json

--- a/charts/tesk/s3-config/config-TEMPLATE
+++ b/charts/tesk/s3-config/config-TEMPLATE
@@ -1,3 +1,3 @@
 [default]
-region=us-west-2
-output=json
+# Non-standard entry, parsed by TESK, not boto3
+endpoint_url=http://localhost:9000

--- a/charts/tesk/s3-config/credentials-TEMPLATE
+++ b/charts/tesk/s3-config/credentials-TEMPLATE
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY

--- a/charts/tesk/templates/storage/aws-secret.yaml
+++ b/charts/tesk/templates/storage/aws-secret.yaml
@@ -1,0 +1,9 @@
+{{ if eq .Values.storage "s3" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s3-conf
+data:
+  config: {{ .Files.Get "s3-conf/config" | b64enc }}
+  credentials: {{ .Files.Get "s3-conf/credentials" | b64enc }}
+{{ end }}

--- a/charts/tesk/values.yaml
+++ b/charts/tesk/values.yaml
@@ -10,6 +10,7 @@ clusterType: kubernetes
 #
 #
 
+# 'openstack' or 's3'
 storage: none
 
 tesk:

--- a/documentation/deployment_new.md
+++ b/documentation/deployment_new.md
@@ -113,7 +113,7 @@ ftp:
 ```
 and additionally provide your username and password in the `secrets.yaml`, as describe [here](../charts/tesk/README.md).
 #### S3
-WiP
+TESK can also utilize S3 object storage for exchanging Inputs & Outputs. If you have an S3 endpoint (AWS, minio, etc) that you want to use, simply add the necessary `config` and `credentials` files (see [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)) under a folder named **s3-config**. You can use the templates provided in *charts/tesk/s3-config* as a point of reference.
 
 ### Authentication and Authorisation
 TESK supports OAuth2/OIDC to authorise API requests. Authentication and authorisation are optional and can be turned off completely. When turned on, TESK API expects an OIDC access token in Authorization Bearer header. TESK can be integrated with any standard OIDC provider, but the solution has been designed to support Elixir AAI in the first place and the authorisation part relies on Elixir's group model. For details, please see [Authentication and Authorisation document](https://github.com/EMBL-EBI-TSI/tesk-api/blob/master/auth.md).


### PR DESCRIPTION
Configuration of the s3 storage option for TESK deployment through a Helm chart, using a secret in the storage template, the necessary config and credentials files and the appropriate 'storage' option in 'values.yaml'.