### PR TITLE
feat: set taskmaster manifest from FOCA config

### DIFF
--- a/deployment/config.yaml
+++ b/deployment/config.yaml
@@ -72,6 +72,23 @@ custom:
     tesResources_backend_parameters:
       - VmSize
       - ParamToRecogniseDataComingFromConfig
+  taskmaster:
+    imageName: docker.io/elixircloud/tesk-core-taskmaster
+    imageVersion: v0.10.2
+    filerImageName: docker.io/elixircloud/tesk-core-filer
+    filerImageVersion: v0.10.2
+    ftp:
+      # Name of the secret with FTP account credentials
+      secretName: account-secret
+      # If FTP account enabled (based on non-emptiness of secretName)
+      enabled: true
+    # If verbose (debug) mode of taskmaster is on (passes additional flag to taskmaster and sets image pull policy to Always)
+    debug: false
+    # Environment variables, that will be passed to taskmaster
+    environment:
+      key: value
+    # Service Account name for taskmaster
+    serviceAccountName: taskmaster
 
 # Logging configuration
 # Cf. https://foca.readthedocs.io/en/latest/modules/foca.models.html#foca.models.config.LogConfig

--- a/deployment/config.yaml
+++ b/deployment/config.yaml
@@ -89,6 +89,8 @@ custom:
       key: value
     # Service Account name for taskmaster
     serviceAccountName: taskmaster
+    filerBackoffLimit: 2
+    executorBackoffLimit: 2
 
 # Logging configuration
 # Cf. https://foca.readthedocs.io/en/latest/modules/foca.models.html#foca.models.config.LogConfig

--- a/tesk/constants.py
+++ b/tesk/constants.py
@@ -27,8 +27,8 @@ class TeskConstants(BaseModel):
     TASKMASTER_IMAGE_NAME: str = "docker.io/elixircloud/tesk-core-taskmaster"
     TASKMASTER_IMAGE_VERSION: str = "latest"
     TASKMASTER_SERVICE_ACCOUNT_NAME: str = "taskmaster"
-    FILER_BACKOFF_LIMIT: int = 2
-    EXECUTOR_BACKOFF_LIMIT: int = 2
+    FILER_BACKOFF_LIMIT: str = "2"
+    EXECUTOR_BACKOFF_LIMIT: str = "2"
 
     class Config:
         """Configuration for class."""

--- a/tesk/constants.py
+++ b/tesk/constants.py
@@ -19,55 +19,16 @@ class TeskConstants(BaseModel):
         TASKMASTER_ENVIRONMENT_EXECUTOR_BACKOFF_LIMIT:  Backoff limit for taskmaster env
         FILER_BACKOFF_LIMIT: Backoff limit got filer job
         EXECUTOR_BACKOFF_LIMIT: Backoff limit for executor job
-
-    Note:
-        Below are the mentioned environment variable with which these constants can be
-        configured, otherwise mentioned default will be assigned.
-
-        variable:
-            ENV_VARIABLE = default
-
-        FILER_IMAGE_NAME:
-            TESK_API_TASKMASTER_FILER_IMAGE_NAME = docker.io/elixircloud/tesk-core-filer
-        FILER_IMAGE_VERSION:
-            TESK_API_TASKMASTER_FILER_IMAGE_VERSION = latest
-        TASKMASTER_IMAGE_NAME:
-            TESK_API_TASKMASTER_IMAGE_NAME = docker.io/elixircloud/tesk-core-taskmaster
-        TASKMASTER_IMAGE_VERSION:
-            TESK_API_TASKMASTER_IMAGE_VERSION = latest
-        TESK_NAMESPACE:
-            TESK_API_K8S_NAMESPACE = tesk
-        TASKMASTER_SERVICE_ACCOUNT_NAME:
-            TESK_API_TASKMASTER_SERVICE_ACCOUNT_NAME = taskmaster
-        TASKMASTER_ENVIRONMENT_EXECUTOR_BACKOFF_LIMIT:
-            ENVIRONMENT_EXECUTOR_BACKOFF_LIMIT = 6
-        FILER_BACKOFF_LIMIT:
-            FILER_BACKOFF_LIMIT = 2
-        EXECUTOR_BACKOFF_LIMIT:
-            EXECUTOR_BACKOFF_LIMIT = 2
     """
 
-    FILER_IMAGE_NAME: str = os.getenv(
-        "TESK_API_TASKMASTER_FILER_IMAGE_NAME", "docker.io/elixircloud/tesk-core-filer"
-    )
-    FILER_IMAGE_VERSION: str = os.getenv(
-        "TESK_API_TASKMASTER_FILER_IMAGE_VERSION", "latest"
-    )
-    TASKMASTER_IMAGE_NAME: str = os.getenv(
-        "TESK_API_TASKMASTER_IMAGE_NAME", "docker.io/elixircloud/tesk-core-taskmaster"
-    )
-    TASKMASTER_IMAGE_VERSION: str = os.getenv(
-        "TESK_API_TASKMASTER_IMAGE_VERSION", "latest"
-    )
     TESK_NAMESPACE: str = os.getenv("TESK_API_K8S_NAMESPACE", "tesk")
-    TASKMASTER_SERVICE_ACCOUNT_NAME: str = os.getenv(
-        "TESK_API_TASKMASTER_SERVICE_ACCOUNT_NAME", "taskmaster"
-    )
-    TASKMASTER_ENVIRONMENT_EXECUTOR_BACKOFF_LIMIT: str = os.getenv(
-        "ENVIRONMENT_EXECUTOR_BACKOFF_LIMIT", "6"
-    )
-    FILER_BACKOFF_LIMIT: str = os.getenv("FILER_BACKOFF_LIMIT", "2")
-    EXECUTOR_BACKOFF_LIMIT: str = os.getenv("EXECUTOR_BACKOFF_LIMIT", "2")
+    FILER_IMAGE_NAME: str = "docker.io/elixircloud/tesk-core-filer"
+    FILER_IMAGE_VERSION: str = "latest"
+    TASKMASTER_IMAGE_NAME: str = "docker.io/elixircloud/tesk-core-taskmaster"
+    TASKMASTER_IMAGE_VERSION: str = "latest"
+    TASKMASTER_SERVICE_ACCOUNT_NAME: str = "taskmaster"
+    FILER_BACKOFF_LIMIT: str = "2"
+    EXECUTOR_BACKOFF_LIMIT: str = "2"
 
     class Config:
         """Configuration for class."""

--- a/tesk/constants.py
+++ b/tesk/constants.py
@@ -27,8 +27,8 @@ class TeskConstants(BaseModel):
     TASKMASTER_IMAGE_NAME: str = "docker.io/elixircloud/tesk-core-taskmaster"
     TASKMASTER_IMAGE_VERSION: str = "latest"
     TASKMASTER_SERVICE_ACCOUNT_NAME: str = "taskmaster"
-    FILER_BACKOFF_LIMIT: str = "2"
-    EXECUTOR_BACKOFF_LIMIT: str = "2"
+    FILER_BACKOFF_LIMIT: int = 2
+    EXECUTOR_BACKOFF_LIMIT: int = 2
 
     class Config:
         """Configuration for class."""

--- a/tesk/custom_config.py
+++ b/tesk/custom_config.py
@@ -1,8 +1,78 @@
 """Custom configuration model for the FOCA app."""
 
-from pydantic import BaseModel
+from typing import Dict, Optional
+
+from pydantic import BaseModel, Field
 
 from tesk.api.ga4gh.tes.models import Service
+from tesk.constants import tesk_constants
+
+
+class FtpConfig(BaseModel):
+    """Ftp configuration model for the TESK."""
+
+    secretName: Optional[str] = Field(
+        default=None, description="Name of the secret with FTP account credentials"
+    )
+    enabled: bool = Field(
+        default=False,
+        description="If FTP account enabled (based on non-emptiness of secretName)",
+    )
+
+
+class ExecutorSecret(BaseModel):
+    """Executor secret configuration."""
+
+    name: Optional[str] = Field(
+        default=None,
+        description=(
+            "Name of a secret that will be mounted as volume to each executor. The same"
+            " name will be used for the secret and the volume"
+        ),
+    )
+    mountPath: Optional[str] = Field(
+        default=None,
+        alias="mountPath",
+        description="The path where the secret will be mounted to executors",
+    )
+    enabled: bool = Field(
+        default=False, description="Indicates whether the secret is enabled"
+    )
+
+
+class Taskmaster(BaseModel):
+    """Taskmaster environment properties model for the TESK."""
+
+    imageName: str = Field(
+        default=tesk_constants.TASKMASTER_IMAGE_NAME,
+        description="Taskmaster image name",
+    )
+    imageVersion: str = Field(
+        default=tesk_constants.TASKMASTER_IMAGE_VERSION,
+        description="Taskmaster image version",
+    )
+    filerImageName: str = Field(
+        default=tesk_constants.FILER_IMAGE_NAME, description="Filer image name"
+    )
+    filerImageVersion: str = Field(
+        default=tesk_constants.FILER_IMAGE_VERSION, description="Filer image version"
+    )
+    ftp: FtpConfig = Field(default=None, description="Test FTP account settings")
+    debug: bool = Field(
+        default=False,
+        description="If verbose (debug) mode of taskmaster is on (passes additional "
+        "flag to taskmaster and sets image pull policy to Always)",
+    )
+    environment: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Environment variables, that will be passed to taskmaster",
+    )
+    serviceAccountName: str = Field(
+        default="default", description="Service Account name for taskmaster"
+    )
+    executorSecret: Optional[ExecutorSecret] = Field(
+        default=None, description="Executor secret configuration"
+    )
 
 
 class CustomConfig(BaseModel):
@@ -10,3 +80,4 @@ class CustomConfig(BaseModel):
 
     # Define custom configuration fields here
     service_info: Service
+    taskmaster: Taskmaster

--- a/tesk/custom_config.py
+++ b/tesk/custom_config.py
@@ -60,6 +60,8 @@ class Taskmaster(BaseModel):
     environment: Optional[Dict[str, str]] = None
     serviceAccountName: str = tesk_constants.TASKMASTER_SERVICE_ACCOUNT_NAME
     executorSecret: Optional[ExecutorSecret] = None
+    filerBackoffLimit: int = tesk_constants.FILER_BACKOFF_LIMIT
+    executorBackoffLimit: int = tesk_constants.EXECUTOR_BACKOFF_LIMIT
 
 
 class CustomConfig(BaseModel):

--- a/tesk/custom_config.py
+++ b/tesk/custom_config.py
@@ -60,8 +60,8 @@ class Taskmaster(BaseModel):
     environment: Optional[Dict[str, str]] = None
     serviceAccountName: str = tesk_constants.TASKMASTER_SERVICE_ACCOUNT_NAME
     executorSecret: Optional[ExecutorSecret] = None
-    filerBackoffLimit: int = tesk_constants.FILER_BACKOFF_LIMIT
-    executorBackoffLimit: int = tesk_constants.EXECUTOR_BACKOFF_LIMIT
+    filerBackoffLimit: str = tesk_constants.FILER_BACKOFF_LIMIT
+    executorBackoffLimit: str = tesk_constants.EXECUTOR_BACKOFF_LIMIT
 
 
 class CustomConfig(BaseModel):

--- a/tesk/custom_config.py
+++ b/tesk/custom_config.py
@@ -2,82 +2,74 @@
 
 from typing import Dict, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from tesk.api.ga4gh.tes.models import Service
 from tesk.constants import tesk_constants
 
 
 class FtpConfig(BaseModel):
-    """Ftp configuration model for the TESK."""
+    """Ftp configuration model for the TESK.
 
-    secretName: Optional[str] = Field(
-        default=None, description="Name of the secret with FTP account credentials"
-    )
-    enabled: bool = Field(
-        default=False,
-        description="If FTP account enabled (based on non-emptiness of secretName)",
-    )
+    Args:
+        secretName: Name of the secret with FTP account credentials.
+        enabled: If FTP account enabled (based on non-emptiness of secretName).
+    """
+
+    secretName: Optional[str] = None
+    enabled: bool = False
 
 
 class ExecutorSecret(BaseModel):
-    """Executor secret configuration."""
+    """Executor secret configuration.
 
-    name: Optional[str] = Field(
-        default=None,
-        description=(
-            "Name of a secret that will be mounted as volume to each executor. The same"
-            " name will be used for the secret and the volume"
-        ),
-    )
-    mountPath: Optional[str] = Field(
-        default=None,
-        alias="mountPath",
-        description="The path where the secret will be mounted to executors",
-    )
-    enabled: bool = Field(
-        default=False, description="Indicates whether the secret is enabled"
-    )
+    Args:
+        name: Name of a secret that will be mounted as volume to each executor. The same
+            name will be used for the secret and the volume.
+        mountPath: The path where the secret will be mounted to executors.
+        enabled: Indicates whether the secret is enabled.
+    """
+
+    name: Optional[str] = None
+    mountPath: Optional[str] = None
+    enabled: bool = False
 
 
 class Taskmaster(BaseModel):
-    """Taskmaster environment properties model for the TESK."""
+    """Taskmaster's configuration model for the TESK.
 
-    imageName: str = Field(
-        default=tesk_constants.TASKMASTER_IMAGE_NAME,
-        description="Taskmaster image name",
-    )
-    imageVersion: str = Field(
-        default=tesk_constants.TASKMASTER_IMAGE_VERSION,
-        description="Taskmaster image version",
-    )
-    filerImageName: str = Field(
-        default=tesk_constants.FILER_IMAGE_NAME, description="Filer image name"
-    )
-    filerImageVersion: str = Field(
-        default=tesk_constants.FILER_IMAGE_VERSION, description="Filer image version"
-    )
-    ftp: FtpConfig = Field(default=None, description="Test FTP account settings")
-    debug: bool = Field(
-        default=False,
-        description="If verbose (debug) mode of taskmaster is on (passes additional "
-        "flag to taskmaster and sets image pull policy to Always)",
-    )
-    environment: Optional[Dict[str, str]] = Field(
-        default=None,
-        description="Environment variables, that will be passed to taskmaster",
-    )
-    serviceAccountName: str = Field(
-        default="default", description="Service Account name for taskmaster"
-    )
-    executorSecret: Optional[ExecutorSecret] = Field(
-        default=None, description="Executor secret configuration"
-    )
+    Args:
+        imageName: Taskmaster image name.
+        imageVersion: Taskmaster image version.
+        filerImageName: Filer image name.
+        filerImageVersion: Filer image version.
+        ftp: FTP account settings.
+        debug: If verbose (debug) mode of taskmaster is on (passes additional flag to
+            taskmaster and sets image pull policy to Always).
+        environment: Environment variables, that will be passed to taskmaster.
+        serviceAccountName: Service Account name for taskmaster.
+        executorSecret: Executor secret configuration
+    """
+
+    imageName: str = tesk_constants.TASKMASTER_IMAGE_NAME
+    imageVersion: str = tesk_constants.TASKMASTER_IMAGE_VERSION
+    filerImageName: str = tesk_constants.FILER_IMAGE_NAME
+    filerImageVersion: str = tesk_constants.FILER_IMAGE_VERSION
+    ftp: FtpConfig = FtpConfig()
+    debug: bool = False
+    environment: Optional[Dict[str, str]] = None
+    serviceAccountName: str = tesk_constants.TASKMASTER_SERVICE_ACCOUNT_NAME
+    executorSecret: Optional[ExecutorSecret] = None
 
 
 class CustomConfig(BaseModel):
-    """Custom configuration model for the FOCA app."""
+    """Custom configuration model for the FOCA app.
+
+    Args:
+        service_info: Service information.
+        taskmaster: Taskmaster environment.
+    """
 
     # Define custom configuration fields here
     service_info: Service
-    taskmaster: Taskmaster
+    taskmaster: Taskmaster = Taskmaster()

--- a/tesk/exceptions.py
+++ b/tesk/exceptions.py
@@ -19,6 +19,10 @@ class ConfigNotFoundError(FileNotFoundError):
     """Configuration file not found error."""
 
 
+class ConfigInvalidError(ValueError):
+    """Configuration file is invalid."""
+
+
 class KubernetesError(ApiException):
     """Kubernetes error."""
 

--- a/tesk/utils.py
+++ b/tesk/utils.py
@@ -24,7 +24,7 @@ from kubernetes.client.models import (
 from tesk.constants import TeskConstants
 from tesk.custom_config import (
     CustomConfig,
-    TaskmasterEnvProperties,
+    Taskmaster,
 )
 from tesk.exceptions import ConfigNotFoundError
 from tesk.k8s.constants import TeskK8sConstants
@@ -151,7 +151,7 @@ def get_taskmaster_template() -> V1Job:
     return job
 
 
-def get_taskmaster_env_property() -> TaskmasterEnvProperties:
+def get_taskmaster_env_property() -> Taskmaster:
     """Get the taskmaster env property from the custom configuration.
 
     Returns:
@@ -159,7 +159,7 @@ def get_taskmaster_env_property() -> TaskmasterEnvProperties:
     """
     custom_conf = get_custom_config()
     try:
-        return custom_conf.taskmaster_env_properties
+        return custom_conf.taskmaster
     except AttributeError:
         raise ConfigNotFoundError(
             "Custom configuration doesn't seem to have taskmaster_env_properties in "

--- a/tesk/utils.py
+++ b/tesk/utils.py
@@ -21,13 +21,13 @@ from kubernetes.client.models import (
     V1VolumeMount,
 )
 
-from tesk.constants import TeskConstants
+from tesk.constants import tesk_constants
 from tesk.custom_config import (
     CustomConfig,
     Taskmaster,
 )
 from tesk.exceptions import ConfigNotFoundError
-from tesk.k8s.constants import TeskK8sConstants
+from tesk.k8s.constants import tesk_k8s_constants
 
 
 def get_config_path() -> Path:
@@ -68,27 +68,26 @@ def get_taskmaster_template() -> V1Job:
         api_version="batch/v1",
         kind="Job",
         metadata=V1ObjectMeta(
-            name=TeskK8sConstants.label_constants.LABEL_JOBTYPE_VALUE_TASKM,
-            labels={"app": TeskK8sConstants.label_constants.LABEL_JOBTYPE_VALUE_TASKM},
+            name=tesk_k8s_constants.label_constants.LABEL_JOBTYPE_VALUE_TASKM,
         ),
         spec=V1JobSpec(
             template=V1PodTemplateSpec(
                 metadata=V1ObjectMeta(
-                    name=TeskK8sConstants.label_constants.LABEL_JOBTYPE_VALUE_TASKM
+                    name=tesk_k8s_constants.label_constants.LABEL_JOBTYPE_VALUE_TASKM
                 ),
                 spec=V1PodSpec(
-                    service_account_name="default",
+                    service_account_name=tesk_constants.TASKMASTER_SERVICE_ACCOUNT_NAME,
                     containers=[
                         V1Container(
-                            name=TeskK8sConstants.label_constants.LABEL_JOBTYPE_VALUE_TASKM,
-                            image=f"{TeskConstants.TASKMASTER_IMAGE_NAME}:{TeskConstants.TASKMASTER_IMAGE_VERSION}",
+                            name=tesk_k8s_constants.label_constants.LABEL_JOBTYPE_VALUE_TASKM,
+                            image=f"{tesk_constants.TASKMASTER_IMAGE_NAME}:{tesk_constants.TASKMASTER_IMAGE_VERSION}",
                             args=[
                                 "-f",
-                                f"/jsoninput/{TeskK8sConstants.job_constants.TASKMASTER_INPUT}.gz",
+                                f"/jsoninput/{tesk_k8s_constants.job_constants.TASKMASTER_INPUT}.gz",
                             ],
                             env=[
                                 V1EnvVar(
-                                    name=TeskK8sConstants.ftp_constants.FTP_SECRET_USERNAME_ENV,
+                                    name=tesk_k8s_constants.ftp_constants.FTP_SECRET_USERNAME_ENV,
                                     value_from=V1EnvVarSource(
                                         secret_key_ref=V1SecretKeySelector(
                                             name="ftp-secret",
@@ -98,7 +97,7 @@ def get_taskmaster_template() -> V1Job:
                                     ),
                                 ),
                                 V1EnvVar(
-                                    name=TeskK8sConstants.ftp_constants.FTP_SECRET_PASSWORD_ENV,
+                                    name=tesk_k8s_constants.ftp_constants.FTP_SECRET_PASSWORD_ENV,
                                     value_from=V1EnvVarSource(
                                         secret_key_ref=V1SecretKeySelector(
                                             name="ftp-secret",
@@ -133,17 +132,11 @@ def get_taskmaster_template() -> V1Job:
                                             field_path="metadata.labels"
                                         ),
                                     ),
-                                    V1DownwardAPIVolumeFile(
-                                        path="annotations",
-                                        field_ref=V1ObjectFieldSelector(
-                                            field_path="metadata.annotations"
-                                        ),
-                                    ),
                                 ]
                             ),
                         ),
                     ],
-                    restart_policy=TeskK8sConstants.k8s_constants.JOB_RESTART_POLICY,
+                    restart_policy=tesk_k8s_constants.k8s_constants.JOB_RESTART_POLICY,
                 ),
             )
         ),

--- a/tesk/utils.py
+++ b/tesk/utils.py
@@ -3,6 +3,28 @@
 import os
 from pathlib import Path
 
+from foca import Foca
+from kubernetes.client.models import (
+    V1Container,
+    V1EnvVar,
+    V1EnvVarSource,
+    V1Job,
+    V1JobSpec,
+    V1ObjectMeta,
+    V1PodSpec,
+    V1PodTemplateSpec,
+    V1SecretKeySelector,
+    V1VolumeMount,
+)
+
+from tesk.constants import TeskConstants
+from tesk.custom_config import (
+    CustomConfig,
+    TaskmasterEnvProperties,
+)
+from tesk.exceptions import ConfigNotFoundError
+from tesk.k8s.constants import TeskK8sConstants
+
 
 def get_config_path() -> Path:
     """Get the configuration path.
@@ -15,3 +37,108 @@ def get_config_path() -> Path:
         return Path(config_path_env).resolve()
     else:
         return (Path(__file__).parents[1] / "deployment" / "config.yaml").resolve()
+
+
+def get_custom_config() -> CustomConfig:
+    """Get the custom configuration.
+
+    Returns:
+      The custom configuration.
+    """
+    conf = Foca(config_file=get_config_path()).conf
+    try:
+        return CustomConfig(**conf.custom)
+    except AttributeError:
+        raise ConfigNotFoundError(
+            "Custom configuration not found in config file."
+        ) from None
+
+
+def get_taskmaster_template() -> V1Job:
+    """Get the taskmaster template from the custom configuration.
+
+    Returns:
+      The taskmaster template.
+    """
+    job = V1Job(
+        api_version="batch/v1",
+        kind="Job",
+        metadata=V1ObjectMeta(
+            name=TeskK8sConstants.label_constants.LABEL_JOBTYPE_VALUE_TASKM,
+            labels={"app": TeskK8sConstants.label_constants.LABEL_JOBTYPE_VALUE_TASKM},
+        ),
+        spec=V1JobSpec(
+            template=V1PodTemplateSpec(
+                metadata=V1ObjectMeta(
+                    name=TeskK8sConstants.label_constants.LABEL_JOBTYPE_VALUE_TASKM
+                ),
+                spec=V1PodSpec(
+                    service_account_name="default",
+                    containers=[
+                        V1Container(
+                            name=TeskK8sConstants.label_constants.LABEL_JOBTYPE_VALUE_TASKM,
+                            image=f"{TeskConstants.TASKMASTER_IMAGE_NAME}:{TeskConstants.TASKMASTER_IMAGE_VERSION}",
+                            args=[
+                                "-f",
+                                f"/jsoninput/{TeskK8sConstants.job_constants.TASKMASTER_INPUT}.gz",
+                            ],
+                            env=[
+                                V1EnvVar(
+                                    name=TeskK8sConstants.ftp_constants.FTP_SECRET_USERNAME_ENV,
+                                    value_from=V1EnvVarSource(
+                                        secret_key_ref=V1SecretKeySelector(
+                                            name="ftp-secret",
+                                            key="username",
+                                            optional=True,
+                                        )
+                                    ),
+                                ),
+                                V1EnvVar(
+                                    name=TeskK8sConstants.ftp_constants.FTP_SECRET_PASSWORD_ENV,
+                                    value_from=V1EnvVarSource(
+                                        secret_key_ref=V1SecretKeySelector(
+                                            name="ftp-secret",
+                                            key="password",
+                                            optional=True,
+                                        )
+                                    ),
+                                ),
+                            ],
+                            volume_mounts=[
+                                V1VolumeMount(
+                                    name="podinfo",
+                                    mount_path="/podinfo",
+                                    read_only=True,
+                                ),
+                                V1VolumeMount(
+                                    name="jsoninput",
+                                    mount_path="/jsoninput",
+                                    read_only=True,
+                                ),
+                            ],
+                        )
+                    ],
+                    volumes=[],
+                    restart_policy=TeskK8sConstants.k8s_constants.JOB_RESTART_POLICY,
+                ),
+            )
+        ),
+    )
+    return job
+
+
+def get_taskmaster_env_property() -> TaskmasterEnvProperties:
+    """Get the taskmaster env property from the custom configuration.
+
+    Returns:
+      The taskmaster env property.
+    """
+    custom_conf = get_custom_config()
+    try:
+        return custom_conf.taskmaster_env_properties
+    except AttributeError:
+        raise ConfigNotFoundError(
+            "Custom configuration doesn't seem to have taskmaster_env_properties in "
+            "config file."
+            f"Custom config:\n{custom_conf}"
+        ) from None

--- a/tesk/utils.py
+++ b/tesk/utils.py
@@ -6,14 +6,18 @@ from pathlib import Path
 from foca import Foca
 from kubernetes.client.models import (
     V1Container,
+    V1DownwardAPIVolumeFile,
+    V1DownwardAPIVolumeSource,
     V1EnvVar,
     V1EnvVarSource,
     V1Job,
     V1JobSpec,
+    V1ObjectFieldSelector,
     V1ObjectMeta,
     V1PodSpec,
     V1PodTemplateSpec,
     V1SecretKeySelector,
+    V1Volume,
     V1VolumeMount,
 )
 
@@ -118,7 +122,27 @@ def get_taskmaster_template() -> V1Job:
                             ],
                         )
                     ],
-                    volumes=[],
+                    volumes=[
+                        V1Volume(
+                            name="podinfo",
+                            downward_api=V1DownwardAPIVolumeSource(
+                                items=[
+                                    V1DownwardAPIVolumeFile(
+                                        path="labels",
+                                        field_ref=V1ObjectFieldSelector(
+                                            field_path="metadata.labels"
+                                        ),
+                                    ),
+                                    V1DownwardAPIVolumeFile(
+                                        path="annotations",
+                                        field_ref=V1ObjectFieldSelector(
+                                            field_path="metadata.annotations"
+                                        ),
+                                    ),
+                                ]
+                            ),
+                        ),
+                    ],
                     restart_policy=TeskK8sConstants.k8s_constants.JOB_RESTART_POLICY,
                 ),
             )

--- a/tesk/utils.py
+++ b/tesk/utils.py
@@ -85,9 +85,9 @@ def get_taskmaster_template() -> V1Job:
     """
     taskmaster_conf: Taskmaster = get_taskmaster_config()
 
-    job = V1Job(
-        api_version="batch/v1",
-        kind="Job",
+    return V1Job(
+        api_version=tesk_k8s_constants.k8s_constants.K8S_BATCH_API_VERSION,
+        kind=tesk_k8s_constants.k8s_constants.K8S_BATCH_API_JOB_TYPE,
         metadata=V1ObjectMeta(
             name=tesk_k8s_constants.label_constants.LABEL_JOBTYPE_VALUE_TASKM,
         ),
@@ -162,4 +162,3 @@ def get_taskmaster_template() -> V1Job:
             )
         ),
     )
-    return job


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Configure the taskmaster manifest from FOCA configuration by adding new methods to retrieve custom configurations and taskmaster templates. Enhance the configuration model to include taskmaster-specific properties, enabling more flexible and dynamic taskmaster setup.

New Features:
- Introduce the ability to configure the taskmaster manifest using FOCA configuration, allowing for dynamic setup of taskmaster properties.

Enhancements:
- Add a new custom configuration model for taskmaster environment properties, including image details, FTP settings, and executor secret configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->